### PR TITLE
Added max capacity to PrefixPool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+.python-version
+
 # C extensions
 *.so
 

--- a/tests/test_prefix.py
+++ b/tests/test_prefix.py
@@ -1,0 +1,46 @@
+from vllm.prefix import PrefixPool
+
+import pytest
+
+@pytest.fixture(scope='module')
+def no_max_capacity_prefix_pool() -> PrefixPool:
+    return PrefixPool(block_size=32)
+                      
+
+def test_prefix_pool_no_max_capacity(no_max_capacity_prefix_pool: PrefixPool):
+    # Test that the same prefix produces the same object even after
+    # multiple repetitions of the object, meaning that no new prefix object
+    # is created, but the one already stored is returned
+    prefix_1 = no_max_capacity_prefix_pool.add_or_get_prefix([1, 2, 3])
+    prefix_2 = no_max_capacity_prefix_pool.add_or_get_prefix([1, 2, 3])
+    assert prefix_1 is prefix_2
+    
+
+def test_prefix_pool_max_capacity():
+    max_capacity = 1
+    max_capacity_prefix_pool = PrefixPool(block_size=32, max_capacity=max_capacity)
+    
+    # Tests that new object is created because capacity limits reached,
+    # but that the newly created object is equal to the old object
+    prefix_1 = max_capacity_prefix_pool.add_or_get_prefix([1, 2, 3])
+    prefix_2 = max_capacity_prefix_pool.add_or_get_prefix([1, 2, 3])
+    assert prefix_1 is not prefix_2
+    assert prefix_1 == prefix_2
+
+    # Tests that the max capacity remains the same
+    for i in range(10):
+        _ = max_capacity_prefix_pool.add_or_get_prefix(list(range(i)))
+        assert len(max_capacity_prefix_pool.prefixes) == max_capacity
+
+
+def test_assertion_raised_with_invalid_max_capacity():
+    with pytest.raises(AssertionError):
+        _ = PrefixPool(32, max_capacity=-1)
+    
+    with pytest.raises(AssertionError):
+        _ = PrefixPool(32, max_capacity=0)
+
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main([__file__])

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -330,35 +330,6 @@ class LLMEngine:
                      log_stats=not engine_args.disable_log_stats)
         return engine
 
-    def add_request_with_prefix(
-        self,
-        request_id,
-        prompt_prefix: str,
-        prompt_suffix: str,
-        sampling_params: SamplingParams,
-        arrival_time: Optional[float] = None,
-    ) -> None:
-        """
-        Adds a request to the engine request pool that includes a prefix
-        prompt in addition to the prompt.  This function tokenizes
-        both the prompt_prefix and the prompt_suffix 
-        (where prompt = prompt_prefix + prompt_suffix) in order to 
-        find what is the prefix_pos.
-
-        It then calls the self.add_request function with the proper params.
-        """
-        prompt_prefix_token_ids = self.tokenizer.encode(prompt_prefix)
-        prompt_suffix_token_ids = self.tokenizer.encode(prompt_suffix)
-        prompt_token_ids = prompt_prefix_token_ids + prompt_suffix_token_ids
-        return self.add_request(
-            request_id=request_id, 
-            prompt=None, 
-            sampling_params=sampling_params,
-            prompt_token_ids = prompt_token_ids,
-            arrival_time=arrival_time,
-            prefix_pos=len(prompt_prefix_token_ids)
-        )
-
     def add_request(
         self,
         request_id: str,

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -330,6 +330,35 @@ class LLMEngine:
                      log_stats=not engine_args.disable_log_stats)
         return engine
 
+    def add_request_with_prefix(
+        self,
+        request_id,
+        prompt_prefix: str,
+        prompt_suffix: str,
+        sampling_params: SamplingParams,
+        arrival_time: Optional[float] = None,
+    ) -> None:
+        """
+        Adds a request to the engine request pool that includes a prefix
+        prompt in addition to the prompt.  This function tokenizes
+        both the prompt_prefix and the prompt_suffix 
+        (where prompt = prompt_prefix + prompt_suffix) in order to 
+        find what is the prefix_pos.
+
+        It then calls the self.add_request function with the proper params.
+        """
+        prompt_prefix_token_ids = self.tokenizer.encode(prompt_prefix)
+        prompt_suffix_token_ids = self.tokenizer.encode(prompt_suffix)
+        prompt_token_ids = prompt_prefix_token_ids + prompt_suffix_token_ids
+        return self.add_request(
+            request_id=request_id, 
+            prompt=None, 
+            sampling_params=sampling_params,
+            prompt_token_ids = prompt_token_ids,
+            arrival_time=arrival_time,
+            prefix_pos=len(prompt_prefix_token_ids)
+        )
+
     def add_request(
         self,
         request_id: str,

--- a/vllm/prefix.py
+++ b/vllm/prefix.py
@@ -32,7 +32,7 @@ class Prefix:
     def get_num_blocks(self) -> int:
         return self.length // self.block_size
 
-    def get_block_numbers(self) -> List[int]:
+    def get_block_numbers(self) -> list[int]:
         return [block.block_number for block in self.block_table]
 
     def get_length(self) -> int:
@@ -54,11 +54,12 @@ class PrefixPool:
     Attributes:
         prefixes: A list of all the prefixes.
         block_size: The block size of the executed model.
+        max_capacity: Max number of prefixes to keep in the pool at any given time.
     """
-
     def __init__(
         self,
         block_size: int,
+        max_capacity: int = 32
     ) -> None:
         self.prefixes: Dict[int, Prefix] = {}
         self.block_size = block_size

--- a/vllm/prefix.py
+++ b/vllm/prefix.py
@@ -32,7 +32,7 @@ class Prefix:
     def get_num_blocks(self) -> int:
         return self.length // self.block_size
 
-    def get_block_numbers(self) -> list[int]:
+    def get_block_numbers(self) -> List[int]:
         return [block.block_number for block in self.block_table]
 
     def get_length(self) -> int:
@@ -46,9 +46,7 @@ class Prefix:
 
 
 class PrefixPool:
-    """Manages all the prompt prefixes. It is bounded by max_capacity.
-    When full, it removes the prefixes that were first inserted (the oldest)
-    ones.
+    """Manages all the prompt prefixes.
 
     Args:
         block_size: The block size of the executed model.
@@ -56,12 +54,11 @@ class PrefixPool:
     Attributes:
         prefixes: A list of all the prefixes.
         block_size: The block size of the executed model.
-        max_capacity: Max number of prefixes to keep in the pool at any given time.
     """
+
     def __init__(
         self,
         block_size: int,
-        max_capacity: int = 32
     ) -> None:
         self.prefixes: Dict[int, Prefix] = {}
         self.block_size = block_size

--- a/vllm/prefix.py
+++ b/vllm/prefix.py
@@ -72,6 +72,8 @@ class PrefixPool:
         # Dictionary from hash of prefix token ids to prefix
         self.prefixes: Dict[int, Prefix] = OrderedDict()
         self.block_size = block_size
+        if max_capacity is not None:
+            assert max_capacity > 0, f"PrefixPool.max_capacity must be greater than 0, but received max_capacity={max_capacity}"
         self.max_capacity = max_capacity
 
     def _truncate_token_ids(self, token_ids: Sequence[int]) -> Tuple[int]:

--- a/vllm/prefix.py
+++ b/vllm/prefix.py
@@ -1,4 +1,5 @@
 from typing import Dict, List, Sequence, Tuple, Optional
+from collections import OrderedDict
 
 from vllm.block import BlockTable
 
@@ -38,9 +39,14 @@ class Prefix:
     def get_length(self) -> int:
         return self.length
 
-    def get_hash(self) -> int:
+    def __hash__(self) -> int:
         return self.hash
-
+    
+    def __eq__(self, other) -> bool:
+        if isinstance(other, Prefix):
+            return self.hash == other.hash
+        return NotImplemented
+    
     def set_block_table(self, block_table: BlockTable) -> None:
         self.block_table = block_table.copy()
 
@@ -54,14 +60,19 @@ class PrefixPool:
     Attributes:
         prefixes: A list of all the prefixes.
         block_size: The block size of the executed model.
+        max_capacity: The maximum number of prefixes to store. By default it stores all the prefixes,
+            so adding this parameter does not modify the behavior of the previous version of the class.
     """
 
     def __init__(
         self,
         block_size: int,
+        max_capacity: Optional[int] = None
     ) -> None:
-        self.prefixes: Dict[int, Prefix] = {}
+        # Dictionary from hash of prefix token ids to prefix
+        self.prefixes: Dict[int, Prefix] = OrderedDict()
         self.block_size = block_size
+        self.max_capacity = max_capacity
 
     def _truncate_token_ids(self, token_ids: Sequence[int]) -> Tuple[int]:
         new_length = len(token_ids) // self.block_size * self.block_size
@@ -73,7 +84,10 @@ class PrefixPool:
             # Prefix is empty.
             return None
         prefix = Prefix(token_ids, self.block_size)
-        prefix_hash = prefix.get_hash()
-        if prefix_hash not in self.prefixes_hash:
+        prefix_hash = hash(prefix)
+        if prefix_hash not in self.prefixes:
+            if self.max_capacity is not None and len(self.prefixes) >= self.max_capacity:
+                # Remove the oldest prefix.
+                self.prefixes.popitem(last=False)
             self.prefixes[prefix_hash] = prefix
         return self.prefixes[prefix_hash]

--- a/vllm/prefix.py
+++ b/vllm/prefix.py
@@ -46,7 +46,9 @@ class Prefix:
 
 
 class PrefixPool:
-    """Manages all the prompt prefixes.
+    """Manages all the prompt prefixes. It is bounded by max_capacity.
+    When full, it removes the prefixes that were first inserted (the oldest)
+    ones.
 
     Args:
         block_size: The block size of the executed model.


### PR DESCRIPTION
- I have fixed a small typo in the `PrefixPool` class that was trying to access a class attribute that existed no longer.
- I have modified the `PrefixPool` class slightly to add support for max_capacity parameter. The class, by default keeps behaving as before when no max_capacity parameter is provided.
- I have added tests that verify that the class is behaving appropriately when using it with and without the max capacity parameter.